### PR TITLE
simplify allocation and fix memory leak

### DIFF
--- a/src/snpdists.c
+++ b/src/snpdists.c
@@ -81,10 +81,10 @@ int compute_distance_matrix(int quiet, int csv, int corner, char* fasta, char* p
       exit(EXIT_FAILURE);
     }
     // keep a copy of the seq and name
-    seq[N] = (char*) calloc(kseq->seq.l + 1, sizeof(char));
-    strcpy(seq[N], kseq->seq.s);
-    name[N] = (char*) calloc(kseq->name.l + 1, sizeof(char));
-    strcpy(name[N], kseq->name.s);
+    seq[N] = malloc(kseq->seq.l + 1);
+    memcpy(seq[N], kseq->seq.s, kseq->seq.l + 1);
+    name[N] = malloc(kseq->name.l + 1);
+    memcpy(name[N], kseq->name.s, kseq->name.l + 1);
     
     // onto the next one!
     N++;
@@ -105,6 +105,11 @@ int compute_distance_matrix(int quiet, int csv, int corner, char* fasta, char* p
   
   print_header(corner, N, sep, name, program_name);
   print_body( N, sep, name, seq, L);
+
+  for (int n = 0; n < N; n++) {
+    free(seq[n]);
+    free(name[n]);
+  }
 
   return 0;
 }


### PR DESCRIPTION
- sizeof(char) is defined as 1
- use malloc, as we don't use zero-initialisation
- don't cast return value [1]
- as we know the length of the string, use memcpy
- also fixes memory leak

using strdup might make things even simples

[1]: http://c-faq.com/malloc/mallocnocast.html