### PR TITLE
Fixes issue #14

### DIFF
--- a/src/snpdists.h
+++ b/src/snpdists.h
@@ -1,17 +1,17 @@
 /*
  *  Torsten Seemann
  *  Copyright (C) 2017 Torsten Seemann
- *  
+ *
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License
  *  as published by the Free Software Foundation; either version 3
  *  of the License, or (at your option) any later version.
- *  
+ *
  *  This program is distributed in the hope that it will be useful,
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU General Public License
  *  along with this program; if not, write to the Free Software
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -30,5 +30,5 @@ int is_acgt(char base);
 int is_unknown(char base);
 
 #define PROGRAM_VERSION PACKAGE_VERSION
-#define MAX_SEQ 1000000
+#define MAX_SEQ 100000
 #endif


### PR DESCRIPTION
Between the release of version 0.2 and 0.4 MAX_SEQ went from 100,000 to 1,000,000. Causing it to segfault. This just brings it back to 100,000. A.