### PR TITLE
added section for container installation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ brew install brewsci/bio/snp-dists
 conda install -c bioconda -c conda-forge snp-dists
 ```
 
+### Containers
+
+Docker images are available on
+[dockerhub](https://hub.docker.com/r/staphb/snp-dists) and [quay.io](https://quay.io/repository/staphb/snp-dists).
+These are maintained by the StaPH-B workgroup. [Dockerfiles can be found here.](https://github.com/StaPH-B/docker-builds)
+
+```
+# Docker
+docker pull staphb/snp-dists:latest
+docker run staphb/snp-dists:latest snp-dists -h
+
+# Singularity
+singularity build snp-dists.sif docker://staphb/snp-dists:latest
+singularity exec snp-dists.sif snp-dists -h
+```
+
+
 ### Source
 
 ```


### PR DESCRIPTION
To quote @andersgs "Please accept my PR..." 😃 

I created a new docker image for v0.8.2 of snp-dists and it's hosted on dockerhub and quay. I'm happy to be responsible for supporting these containers, should anyone file an issue regarding them.

Dockerfile here for reference: https://github.com/StaPH-B/docker-builds/blob/master/snp-dists/0.8.2/Dockerfile

Until a there is a new release of snp-dists, the docker image tag `latest` corresponds with v0.8.2

Seems to pass the included tests with no issues (as far as I can tell?):
```
$ docker pull staphb/snp-dists:latest
latest: Pulling from staphb/snp-dists
528184910841: Pull complete
8a9df81d603d: Pull complete
636d9303bf66: Pull complete
672b5bdcef61: Pull complete
0a543aee32a1: Pull complete
65477f5fd0ee: Pull complete
4f4fb700ef54: Pull complete
Digest: sha256:a0636c33a966ac5378fe01e5147ad3aed56d937f10de44f8975ebe9b31d26b15
Status: Downloaded newer image for staphb/snp-dists:latest
docker.io/staphb/snp-dists:latest

$ docker run staphb/snp-dists:latest snp-dists -h
SYNOPSIS
  Pairwise SNP distance matrix from a FASTA alignment
USAGE
  snp-dists [opts] aligned.fasta[.gz] > matrix.tsv
OPTIONS
  -h       Show this help
  -v       Print version and exit
  -j CPUS  Threads to use [1]
  -q       Quiet mode; no progress messages
  -a       Count all differences not just [AGTC]
  -k       Keep case, don't uppercase all letters
  -m       Output MOLTEN instead of TSV
  -c       Use comma instead of tab in output
  -b       Blank top left corner cell
URL
  https://github.com/tseemann/snp-dists

$ docker run staphb/snp-dists:latest /bin/bash -c 'cd /snp-dists-0.8.2; make check'
./snp-dists -v
snp-dists 0.8.2
./snp-dists /dev/null || true
This is snp-dists 0.8.2
Will use 1 threads.
ERROR: file contained no sequences
./snp-dists -qb test/singleton.aln | diff -bB - test/singleton.res
./snp-dists -qb test/good.aln | diff -bB - test/good.res
./snp-dists -qb test/gzip.aln.gz | diff -bB -  test/gzip.res
./snp-dists -qb -k test/lowercase.aln | diff -bB - test/lowercase-k.res
./snp-dists -qb    test/lowercase.aln | diff -bB - test/lowercase.res
./snp-dists -qb -c -q test/good.aln | diff -bB - test/good-c.res
./snp-dists -qb -a test/ambig.aln | diff -bB - test/ambig-a.res
./snp-dists -qbcm test/good.aln | diff -bB - test/good-c-m.res
./snp-dists -qb    test/ambig.aln | diff -bB - test/ambig.res
```

Tested fine with singularity as well.