### PR TITLE
Improve parallelisation

### DIFF
--- a/main.c
+++ b/main.c
@@ -47,7 +47,7 @@ void show_help(int retcode)
       "  -a       Count all differences not just [AGTC]\n"
       "  -k       Keep case, don't uppercase all letters\n"
       "  -m       Output MOLTEN instead of TSV\n"
-      "  -L       Ootput lower-trangle only (unique pairs)\n"
+      "  -L       Output lower-trangle only (unique pairs)\n"
       "  -t       Add header to MOLTEN output\n"
       "  -c       Use comma instead of tab in output\n"
       "  -b       Blank top left corner cell\n"
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
 {
   // parse command line parameters
   int opt, quiet = 0, csv = 0, corner = 1, allchars = 0, keepcase = 0;
-  int  moltenheader = 0, molten = 0, maxdiff = 9999999;
+  int moltenheader = 0, molten = 0, maxdiff = 9999999;
   int lower = 0;
 
   while ((opt = getopt(argc, argv, "hj:qcakmtbx:vL")) != -1) {


### PR DESCRIPTION
Happy 2026 all round!

I like the improvements in multi-threading, but as implemented there are issues with the output. On larger datasets the output will be jumbled as the prints may happen in arbitrary order. So we have to separate the computation, parallelize that and then use the main thread for the output. Unfortunately, this requires us to store a matrix of O(N^2). Use molten if that should be an issue.

The two sequence parameters in the distance function were marked as `restrict`. That means we cannot pass in the same sequence to implicitly get zero. I fixed that by skipping the self-comparison.